### PR TITLE
Fix compilation error on recent rust versions caused by #[macro_export]

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,7 +2,7 @@ use std::fs;
 
 use log::*;
 
-#[macro_export()]
+#[macro_export]
 macro_rules! die {
     ($($arg:tt)+) => {log::error!("FATAL: {}", format!($($arg)+)); std::process::exit(1);}
 }


### PR DESCRIPTION
Changed #[macro_export()] to #[macro_export] in src/utils.rs
See issue <https://github.com/rust-lang/rust/issues/57571>

Rust no longer accepts empty arguments for `#[macro_export()]` causing the crate to fail to compile with `#[deny(invalid_macro_export_arguments)]` removing brackets fixes it.

Compiled on: `cargo 1.92.0 (344c4567c 2025-10-21) (Arch Linux rust 1:1.92.0-1)`